### PR TITLE
`output` callback for h264 stream data

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,3 @@
-extern crate rpi_video_rs;
-
 use rpi_video_rs::recorder::Recorder;
 
 fn main() {

--- a/src/encoder_component.rs
+++ b/src/encoder_component.rs
@@ -1,10 +1,12 @@
-extern crate rpi_mmal_rs as mmal;
-
 use std::ptr;
+
+use rpi_mmal_rs as mmal;
+
 use crate::video_error::VideoError;
 use crate::video_input_port::VideoInputPort;
 use crate::video_output_port::VideoOutputPort;
 use crate::video_param::VideoParam;
+use crate::video_pool::VideoPool;
 
 pub struct EncoderComponent {
     mmal_encoder_com: *mut mmal::MMAL_COMPONENT_T,
@@ -252,5 +254,11 @@ impl VideoOutputPort for EncoderComponent {
         unsafe {
             *(*self.mmal_encoder_com).output.offset(0)
         }
+    }
+}
+
+impl VideoPool for EncoderComponent {
+    fn raw_pool(&self) -> *mut mmal::MMAL_POOL_T {
+        self.mmal_encoder_pool
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@ mod camera_component;
 mod encoder_component;
 mod video_conn;
 mod video_input_port;
+mod video_output;
 mod video_output_port;
+mod video_pool;
 mod video_state;
 
 pub mod recorder;

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -2,6 +2,7 @@ use crate::camera_component::CameraComponent;
 use crate::encoder_component::EncoderComponent;
 use crate::video_conn::VideoConn;
 use crate::video_error::VideoError;
+use crate::video_output::output_processor::OutputProcessor;
 use crate::video_param::VideoParam;
 use crate::video_res::VideoRes;
 use crate::video_state::VideoState;
@@ -10,6 +11,7 @@ pub struct Recorder {
     camera_com: CameraComponent,
     encoder_com: EncoderComponent,
     encoder_conn: VideoConn,
+    output_processor: OutputProcessor,
     param: VideoParam,
     state: VideoState,
 }
@@ -27,29 +29,29 @@ impl Recorder {
             camera_com: CameraComponent::new(param.clone()),
             encoder_com: EncoderComponent::new(param.clone()),
             encoder_conn: VideoConn::new(),
+            output_processor: OutputProcessor::new(),
             param: param,
         }
     }
 
     pub fn run(&mut self) -> Result<VideoRes, VideoError> {
-        if let Err(error) = self.init_camera_com() {
-            return Err(error)
-        }
-
-        if let Err(error) = self.init_encoder_com() {
-            return Err(error)
-        }
-
-        if let Err(error) = self.init_encoder_conn() {
-            return Err(error)
-        }
-
-        if let Err(error) = self.init_state() {
-            return Err(error)
-        }
+        self.init_camera_com()?;
+        self.init_encoder_com()?;
+        self.init_encoder_conn()?;
+        self.init_state()?;
+        self.init_output_processor()?;
+        self.enable_capture()?;
 
 
-        Ok(VideoRes::new())
+        let video_res = VideoRes {
+            output_file_path: self.param.output_file_path.clone(),
+        };
+
+        Ok(video_res)
+    }
+
+    fn enable_capture(&self) -> Result<(), VideoError> {
+        self.camera_com.enable_capture()
     }
 
     fn init_camera_com(&mut self) -> Result<(), VideoError> {
@@ -62,6 +64,10 @@ impl Recorder {
 
     fn init_encoder_conn(&mut self) -> Result<(), VideoError> {
         self.encoder_conn.init(&self.encoder_com, &self.camera_com)
+    }
+
+    fn init_output_processor(&mut self) -> Result<(), VideoError> {
+        self.output_processor.init(&self.encoder_com, &self.encoder_com)
     }
 
     fn init_state(&mut self) -> Result<(), VideoError> {

--- a/src/video_conn.rs
+++ b/src/video_conn.rs
@@ -1,6 +1,7 @@
-extern crate rpi_mmal_rs as mmal;
-
 use std::ptr;
+
+use rpi_mmal_rs as mmal;
+
 use crate::video_error::VideoError;
 use crate::video_input_port::VideoInputPort;
 use crate::video_output_port::VideoOutputPort;

--- a/src/video_error.rs
+++ b/src/video_error.rs
@@ -1,7 +1,7 @@
-extern crate rpi_mmal_rs as mmal;
-
 use std::error;
 use std::fmt;
+
+use rpi_mmal_rs as mmal;
 
 #[derive(Debug, Clone)]
 pub struct VideoError {

--- a/src/video_input_port.rs
+++ b/src/video_input_port.rs
@@ -1,4 +1,4 @@
-extern crate rpi_mmal_rs as mmal;
+use rpi_mmal_rs as mmal;
 
 pub trait VideoInputPort {
     fn raw_input_port(&self) -> *mut mmal::MMAL_PORT_T;

--- a/src/video_output.rs
+++ b/src/video_output.rs
@@ -1,0 +1,4 @@
+mod output_buffer;
+mod output_callback_user_data;
+
+pub mod output_processor;

--- a/src/video_output/output_buffer.rs
+++ b/src/video_output/output_buffer.rs
@@ -1,0 +1,9 @@
+pub struct OutputBuffer {
+}
+
+impl OutputBuffer {
+    pub fn new() -> Self {
+        OutputBuffer {
+        }
+    }
+}

--- a/src/video_output/output_callback_user_data.rs
+++ b/src/video_output/output_callback_user_data.rs
@@ -1,0 +1,10 @@
+use std::sync::mpsc;
+
+use rpi_mmal_rs as mmal;
+
+use crate::video_output::output_buffer::OutputBuffer;
+
+pub struct OutputCallbackUserData {
+    pub buffer_sender: mpsc::SyncSender<Option<OutputBuffer>>,
+    pub mmal_pool: *mut mmal::MMAL_POOL_T,
+}

--- a/src/video_output/output_processor.rs
+++ b/src/video_output/output_processor.rs
@@ -1,0 +1,101 @@
+use std::ptr;
+use std::sync::mpsc;
+
+use rpi_mmal_rs as mmal;
+
+use crate::video_error::VideoError;
+use crate::video_output::output_buffer::OutputBuffer;
+use crate::video_output::output_callback_user_data::OutputCallbackUserData;
+use crate::video_output_port::VideoOutputPort;
+use crate::video_pool::VideoPool;
+
+pub struct OutputProcessor {
+    buffer_receiver: Option<mpsc::Receiver<Option<OutputBuffer>>>,
+}
+
+impl OutputProcessor {
+    pub fn new() -> Self {
+        OutputProcessor {
+            buffer_receiver: None,
+        }
+    }
+
+    pub fn init(
+        &mut self,
+        output_port: &dyn VideoOutputPort,
+        pool: &dyn VideoPool
+    ) -> Result<(), VideoError> {
+        let (buffer_sender, buffer_receiver) = mpsc::sync_channel(0);
+        self.buffer_receiver = Some(buffer_receiver);
+
+        let user_data = OutputCallbackUserData {
+            buffer_sender: buffer_sender,
+            mmal_pool: pool.raw_pool(),
+        };
+
+        let mmal_port = output_port.raw_output_port();
+
+        let status = unsafe {
+            (*mmal_port).userdata =
+                Box::into_raw(Box::new(user_data)) as *mut mmal::MMAL_PORT_USERDATA_T;
+
+            mmal::mmal_port_enable(mmal_port, Some(output_callback))
+        };
+
+        if status != mmal::MMAL_STATUS_T::MMAL_SUCCESS {
+            let err_message = "Failed to invoke `mmal_port_enable`".to_string();
+
+            let error = VideoError {
+                message: err_message,
+                mmal_status: status,
+            };
+
+            return Err(error);
+        }
+
+        Ok(())
+    }
+}
+
+unsafe extern "C" fn output_callback(
+    mmal_port: *mut mmal::MMAL_PORT_T,
+    mmal_buffer: *mut mmal::MMAL_BUFFER_HEADER_T
+) {
+    if mmal_port.is_null() || mmal_buffer.is_null() {
+        panic!("`mmal_port` or `mmal_buffer` is NULL");
+    }
+
+    let user_data_ptr = (*mmal_port).userdata as *mut OutputCallbackUserData;
+    if user_data_ptr.is_null() {
+        panic!("`mmal_port.userdata` is NULL");
+    }
+
+    let user_data = &mut *user_data_ptr;
+
+    let buffer_len = (*mmal_buffer).length;
+    if buffer_len > 0 {
+        mmal::mmal_buffer_header_mem_lock(mmal_buffer);
+
+        let output_buffer = OutputBuffer::new();
+
+        user_data.buffer_sender.send(Some(output_buffer));
+
+        mmal::mmal_buffer_header_mem_unlock(mmal_buffer);
+    }
+
+    mmal::mmal_buffer_header_release(mmal_buffer);
+
+    if (*mmal_port).is_enabled != 0 {
+        let new_mmal_buffer: *mut mmal::MMAL_BUFFER_HEADER_T =
+            mmal::mmal_queue_get((*user_data.mmal_pool).queue);
+
+        if new_mmal_buffer.is_null() {
+            panic!("`new_mmal_buffer` is NULL");
+        }
+
+        let status = mmal::mmal_port_send_buffer(mmal_port, new_mmal_buffer);
+        if status != mmal::MMAL_STATUS_T::MMAL_SUCCESS {
+            panic!("`mmal_port_send_buffer` returns an error");
+        }
+   }
+}

--- a/src/video_output_port.rs
+++ b/src/video_output_port.rs
@@ -1,4 +1,4 @@
-extern crate rpi_mmal_rs as mmal;
+use rpi_mmal_rs as mmal;
 
 pub trait VideoOutputPort {
     fn raw_output_port(&self) -> *mut mmal::MMAL_PORT_T;

--- a/src/video_pool.rs
+++ b/src/video_pool.rs
@@ -1,0 +1,5 @@
+use rpi_mmal_rs as mmal;
+
+pub trait VideoPool {
+    fn raw_pool(&self) -> *mut mmal::MMAL_POOL_T;
+}

--- a/src/video_state.rs
+++ b/src/video_state.rs
@@ -1,7 +1,8 @@
-extern crate rpi_mmal_rs as mmal;
-
 use std::fs::{OpenOptions, File};
 use std::path::Path;
+
+use rpi_mmal_rs as mmal;
+
 use crate::video_error::VideoError;
 use crate::video_param::VideoParam;
 


### PR DESCRIPTION
### Summary

Implements `output` callback to handle h264 stream data, and deletes useless `extern create` for new Rust version.