### PR TITLE
Fix issue of record cannot complete

### DIFF
--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -40,8 +40,8 @@ impl Recorder {
 
         self.wait();
 
-        self.write_output()?;
         self.disable_output();
+        self.write_output()?;
 
         self.destroy();
 

--- a/src/video_output/output_buffer.rs
+++ b/src/video_output/output_buffer.rs
@@ -9,6 +9,10 @@ impl OutputBuffer {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.vec_data.len()
+    }
+
     pub fn raw_data(&self) -> &[u8] {
         self.vec_data.as_slice()
     }

--- a/src/video_output/output_callback_user_data.rs
+++ b/src/video_output/output_callback_user_data.rs
@@ -5,6 +5,6 @@ use std::sync::mpsc;
 use crate::video_output::output_buffer::OutputBuffer;
 
 pub struct OutputCallbackUserData {
-    pub buffer_sender: mpsc::SyncSender<Option<OutputBuffer>>,
+    pub buffer_sender: mpsc::Sender<Option<OutputBuffer>>,
     pub mmal_pool: *mut mmal::MMAL_POOL_T,
 }

--- a/src/video_output/output_processor.rs
+++ b/src/video_output/output_processor.rs
@@ -25,7 +25,7 @@ impl OutputProcessor {
         output_port: &dyn VideoOutputPort,
         pool: &dyn VideoPool
     ) -> Result<(), VideoError> {
-        let (buffer_sender, buffer_receiver) = mpsc::sync_channel(0);
+        let (buffer_sender, buffer_receiver) = mpsc::channel();
         self.buffer_receiver = Some(buffer_receiver);
 
         let user_data = OutputCallbackUserData {
@@ -125,6 +125,9 @@ unsafe extern "C" fn output_callback(
         mmal::mmal_buffer_header_mem_unlock(mmal_buffer);
 
         user_data.buffer_sender.send(Some(output_buffer)).unwrap();
+    } else {
+        // Notifies the end of buffer frames (record complete).
+        user_data.buffer_sender.send(None).unwrap();
     }
 
     mmal::mmal_buffer_header_release(mmal_buffer);


### PR DESCRIPTION
### Summary

This PR fixes Issue #14 - record cannot complete.

1. Disables the encode-output-port before reading data from channel. It is used for stopping the record process.

2. Sends `None` to the channel for notifying the end of buffer frames.

3. Replace `sync_channel` with async channel.